### PR TITLE
Add support for Laravel 12 and 13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,4 +51,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --no-coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,17 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [11.*, 10.*]
+        php: [8.4, 8.3, 8.2]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,24 +22,24 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/console": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/notifications": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "spatie/laravel-package-tools": "^1.14.1"
+        "php": "^8.2",
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/notifications": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8|^8.1",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
-        "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.3",
+        "nunomaduro/collision": "^8.1",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
         "spatie/pest-plugin-test-time": "^2.1"
     },
     "autoload": {

--- a/config/model-expires.php
+++ b/config/model-expires.php
@@ -1,5 +1,8 @@
 <?php
 
+use Maize\ModelExpires\Models\Expiration;
+use Maize\ModelExpires\Notifications\ModelExpiringNotification;
+
 return [
 
     /*
@@ -11,7 +14,7 @@ return [
     |
     */
 
-    'expiration_model' => Maize\ModelExpires\Models\Expiration::class,
+    'expiration_model' => Expiration::class,
 
     'model' => [
 
@@ -66,7 +69,7 @@ return [
         |
         */
 
-        'notification' => Maize\ModelExpires\Notifications\ModelExpiringNotification::class,
+        'notification' => ModelExpiringNotification::class,
 
         /*
         |--------------------------------------------------------------------------

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,10 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        # HasExpiration is the package's public API trait, consumed by host
+        # application models rather than by classes within the analysed paths.
+        -
+            identifier: trait.unused
+            path: src/HasExpiration.php
 

--- a/src/Events/ExpiredModelsDeleted.php
+++ b/src/Events/ExpiredModelsDeleted.php
@@ -11,6 +11,5 @@ class ExpiredModelsDeleted
     public function __construct(
         public string $model,
         public int $count
-    ) {
-    }
+    ) {}
 }

--- a/src/Events/ModelExpiring.php
+++ b/src/Events/ModelExpiring.php
@@ -11,6 +11,5 @@ class ModelExpiring
 
     public function __construct(
         public Model $model
-    ) {
-    }
+    ) {}
 }

--- a/src/Models/Expiration.php
+++ b/src/Models/Expiration.php
@@ -9,7 +9,7 @@ class Expiration extends Model
 {
     use HasFactory;
 
-    /** @var array<int, string> */
+    /** @var list<string> */
     protected $fillable = [
         'model_id',
         'model_type',

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -26,7 +26,7 @@ class Config
         }
 
         if ($days < 1) {
-            throw new Exception();
+            throw new Exception;
         }
 
         return now()
@@ -43,7 +43,7 @@ class Config
         }
 
         if ($days < 1) {
-            throw new Exception();
+            throw new Exception;
         }
 
         return static::defaultExpiresAt()

--- a/tests/HasExpirationTest.php
+++ b/tests/HasExpirationTest.php
@@ -34,7 +34,7 @@ it('can create model with default expiration', function (string $model, ?int $ex
     ],
     [
         'model' => Tenant::class,
-        'expiresAt' => fn () => now()->startOfDay()->addDays(365)->timestamp,
+        'expiresAt' => now()->startOfDay()->addDays(365)->timestamp,
         'deletesAt' => null,
     ],
 ]);
@@ -64,10 +64,10 @@ it('can set expires_at', function (string $model, int $index, int $days, ?Carbon
     ['model' => User::class, 'index' => 1, 'days' => 4, 'default' => null],
     ['model' => User::class, 'index' => 2, 'days' => 20, 'default' => null],
     ['model' => User::class, 'index' => 2, 'days' => -10, 'default' => null],
-    ['model' => Tenant::class, 'index' => 0, 'days' => 2, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 1, 'days' => 4, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 2, 'days' => 20, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 2, 'days' => -10, 'default' => fn () => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 0, 'days' => 2, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 1, 'days' => 4, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 2, 'days' => 20, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 2, 'days' => -10, 'default' => now()->startOfDay()->addDays(365)],
 ]);
 
 it('can get expires_at', function (string $model, int $index, int $days, ?Carbon $default) {
@@ -94,10 +94,10 @@ it('can get expires_at', function (string $model, int $index, int $days, ?Carbon
     ['model' => User::class, 'index' => 1, 'days' => 4, 'default' => null],
     ['model' => User::class, 'index' => 2, 'days' => 20, 'default' => null],
     ['model' => User::class, 'index' => 2, 'days' => -10, 'default' => null],
-    ['model' => Tenant::class, 'index' => 0, 'days' => 2, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 1, 'days' => 4, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 2, 'days' => 20, 'default' => fn () => now()->startOfDay()->addDays(365)],
-    ['model' => Tenant::class, 'index' => 2, 'days' => -10, 'default' => fn () => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 0, 'days' => 2, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 1, 'days' => 4, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 2, 'days' => 20, 'default' => now()->startOfDay()->addDays(365)],
+    ['model' => Tenant::class, 'index' => 2, 'days' => -10, 'default' => now()->startOfDay()->addDays(365)],
 ]);
 
 it('can get isExpired', function (string $model, int $index, int $months) {
@@ -150,9 +150,9 @@ it('can get getDaysLeftToExpiration', function (string $model, int $index, int $
     ['model' => User::class, 'index' => 0, 'days' => -1, 'default' => null, 'remainingIndex' => 0, 'remaining' => null],
     ['model' => User::class, 'index' => 1, 'days' => 5, 'default' => null, 'remainingIndex' => 1, 'remaining' => null],
     ['model' => User::class, 'index' => 2, 'days' => 10, 'default' => null, 'remainingIndex' => 6, 'remaining' => null],
-    ['model' => Tenant::class, 'index' => 0, 'days' => -1, 'default' => 365, 'remaining' => 0, 'remainingIndex' => 361],
-    ['model' => Tenant::class, 'index' => 1, 'days' => 5, 'default' => 365, 'remaining' => 1, 'remainingIndex' => fn () => 361],
-    ['model' => Tenant::class, 'index' => 2, 'days' => 10, 'default' => 365, 'remaining' => 6, 'remainingIndex' => fn () => 361],
+    ['model' => Tenant::class, 'index' => 0, 'days' => -1, 'default' => 365, 'remainingIndex' => 0, 'remaining' => 361],
+    ['model' => Tenant::class, 'index' => 1, 'days' => 5, 'default' => 365, 'remainingIndex' => 1, 'remaining' => 361],
+    ['model' => Tenant::class, 'index' => 2, 'days' => 10, 'default' => 365, 'remainingIndex' => 6, 'remaining' => 361],
 ]);
 
 it('can get canExpire', function (string $model, int $index, int $days, bool $default) {


### PR DESCRIPTION
## Summary
Adds support for **Laravel 11, 12 and 13** and drops the EOL Laravel 10. Tooling is bumped to the minimum required to run on Laravel 13 (Testbench 11 → PHPUnit 12 → Pest 4, and Larastan 3 / PHPStan 2 for static analysis), while keeping wide version ranges so Laravel 11 still resolves older tooling on `prefer-lowest`.

## Changes
- **composer.json**: `php` → `^8.2`; `illuminate/*` → `^11.0|^12.0|^13.0`; `spatie/laravel-package-tools` → `^1.16`. Dev deps: `orchestra/testbench ^9|^10|^11`, `pestphp/pest ^3|^4` (+ plugins), `nunomaduro/larastan` → `larastan/larastan ^3.0`, `phpstan/* ^2.0`, `collision ^8.1`.
- **CI**: `run-tests.yml` matrix → PHP 8.2/8.3/8.4 × Laravel 11/12/13 (testbench 9/10/11, L13 excluded on 8.2); `phpstan.yml` runs on PHP 8.3 (required by Larastan 3).
- **phpstan.neon.dist**: removed `checkMissingIterableValueType` (gone in PHPStan 2); ignore `trait.unused` for `HasExpiration` (it's the package's public API trait).
- **src/Models/Expiration.php**: `$fillable` PHPDoc widened to `list<string>` for Larastan 3 covariance.
- **tests/HasExpirationTest.php**: aligned datasets with PHPUnit 11+ by-name binding and dropped closure values that Pest 3 does not resolve. No functional behavior change.

## Verification (local, via Herd)
| Combination | Result |
|---|---|
| Laravel 13 / PHP 8.4 / prefer-stable (Pest 4, Testbench 11) | ✅ 51 passed |
| Laravel 12 / PHP 8.3 / prefer-stable (Testbench 10) | ✅ 51 passed |
| Laravel 11 / PHP 8.2 / prefer-lowest (Pest 3, Testbench 9) | ✅ 51 passed |
| PHPStan (Larastan 3 / PHPStan 2) | ✅ No errors |
| Pint | ✅ clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)